### PR TITLE
Do not try to coerce "" for numeric & date params

### DIFF
--- a/lib/rails_param/coercion/big_decimal_param.rb
+++ b/lib/rails_param/coercion/big_decimal_param.rb
@@ -4,6 +4,8 @@ module RailsParam
       DEFAULT_PRECISION = 14
 
       def coerce
+        return nil if param == '' # e.g. from an empty field in an HTML form
+
         stripped_param = if param.is_a?(String)
                             param.delete('$,').strip.to_f
                           else

--- a/lib/rails_param/coercion/float_param.rb
+++ b/lib/rails_param/coercion/float_param.rb
@@ -2,6 +2,8 @@ module RailsParam
   class Coercion
     class FloatParam < VirtualParam
       def coerce
+        return nil if param == '' # e.g. from an empty field in an HTML form
+
         Float(param)
       end
     end

--- a/lib/rails_param/coercion/integer_param.rb
+++ b/lib/rails_param/coercion/integer_param.rb
@@ -2,6 +2,8 @@ module RailsParam
   class Coercion
     class IntegerParam < VirtualParam
       def coerce
+        return nil if param == '' # e.g. from an empty field in an HTML form
+
         Integer(param)
       end
     end

--- a/lib/rails_param/coercion/time_param.rb
+++ b/lib/rails_param/coercion/time_param.rb
@@ -2,6 +2,8 @@ module RailsParam
   class Coercion
     class TimeParam < VirtualParam
       def coerce
+        return nil if param == '' # e.g. from an empty field in an HTML form
+
         return type.strptime(param, options[:format]) if options[:format].present?
 
         type.parse(param)

--- a/spec/rails_param/coercion/big_decimal_param_spec.rb
+++ b/spec/rails_param/coercion/big_decimal_param_spec.rb
@@ -13,6 +13,12 @@ describe RailsParam::Coercion::BigDecimalParam do
       end
     end
 
+    shared_examples "returns nil" do
+      it "returns the param as a nil value" do
+        expect(subject.coerce).to be nil
+      end
+    end
+
     it_behaves_like "returns BigDecimal with default precision"
 
     context "given a precision option" do
@@ -34,6 +40,12 @@ describe RailsParam::Coercion::BigDecimalParam do
         it "returns the param as BigDecimal" do
           expect(subject.coerce).to eq 1.50
         end
+      end
+
+      context "param is blank (e.g. empty field in an HTML form)" do
+        let(:param) { "" }
+
+        it_behaves_like "returns nil"
       end
     end
   end

--- a/spec/rails_param/coercion/float_param_spec.rb
+++ b/spec/rails_param/coercion/float_param_spec.rb
@@ -6,20 +6,48 @@ describe RailsParam::Coercion::FloatParam do
     let(:options) { {} }
     subject { described_class.new(param: param, type: type, options: options) }
 
+    shared_examples "does not raise an error" do
+      it "does not raise an error" do
+        expect { subject.coerce }.to_not raise_error
+      end
+    end
+
+    shared_examples "raises ArgumentError" do
+      it "raises ArgumentError" do
+        expect { subject.coerce }.to raise_error ArgumentError
+      end
+    end
+
+    shared_examples "returns a Float" do
+      it "returns the param as a Float" do
+        expect(subject.coerce).to eq 12.34
+      end
+    end
+
+    shared_examples "returns nil" do
+      it "returns the param as a nil value" do
+        expect(subject.coerce).to be nil
+      end
+    end
+
     context "value is valid" do
       let(:param) { "12.34" }
 
-      it "returns a Float" do
-        expect(subject.coerce).to eq 12.34
-      end
+      it_behaves_like "does not raise an error"
+      it_behaves_like "returns a Float"
+    end
+
+    context "param is blank (e.g. empty field in an HTML form)" do
+      let(:param) { "" }
+
+      it_behaves_like "does not raise an error"
+      it_behaves_like "returns nil"
     end
 
     context "value is invalid" do
       let(:param) { "foo" }
 
-      it "raises ArgumentError" do
-        expect { subject.coerce }.to raise_error ArgumentError
-      end
+      it_behaves_like "raises ArgumentError"
     end
   end
 end

--- a/spec/rails_param/coercion/integer_param_spec.rb
+++ b/spec/rails_param/coercion/integer_param_spec.rb
@@ -1,34 +1,47 @@
 require 'spec_helper'
 
 describe RailsParam::Coercion::IntegerParam do
-  shared_examples "does not raise an error" do
-    it "does not raise an error" do
-      expect { subject.coerce }.to_not raise_error
-    end
-  end
-
-  shared_examples "raises ArgumentError" do
-    it "raises ArgumentError" do
-      expect { subject.coerce }.to raise_error ArgumentError
-    end
-  end
-
-  shared_examples "returns an Integer" do
-    it "returns the param as an Integer" do
-      expect(subject.coerce).to eq 19
-    end
-  end
-
   describe "#coerce" do
     let(:type)    { Integer }
     let(:options) { {} }
     subject { described_class.new(param: param, type: type, options: options) }
+
+    shared_examples "does not raise an error" do
+      it "does not raise an error" do
+        expect { subject.coerce }.to_not raise_error
+      end
+    end
+
+    shared_examples "raises ArgumentError" do
+      it "raises ArgumentError" do
+        expect { subject.coerce }.to raise_error ArgumentError
+      end
+    end
+
+    shared_examples "returns an Integer" do
+      it "returns the param as an Integer" do
+        expect(subject.coerce).to eq 19
+      end
+    end
+
+    shared_examples "returns nil" do
+      it "returns the param as a nil value" do
+        expect(subject.coerce).to be nil
+      end
+    end
 
     context "param is a valid value" do
       let(:param) { "19" }
 
       it_behaves_like "does not raise an error"
       it_behaves_like "returns an Integer"
+    end
+
+    context "param is blank (e.g. empty field in an HTML form)" do
+      let(:param) { "" }
+
+      it_behaves_like "does not raise an error"
+      it_behaves_like "returns nil"
     end
 
     context "param is invalid value" do

--- a/spec/rails_param/coercion/time_param_spec.rb
+++ b/spec/rails_param/coercion/time_param_spec.rb
@@ -56,6 +56,12 @@ describe RailsParam::Coercion::TimeParam do
       end
     end
 
+    shared_examples "returns nil" do
+      it "returns the param as a nil value" do
+        expect(subject.coerce).to be nil
+      end
+    end
+
     let(:options) { {} }
     subject { described_class.new(param: param, type: type, options: options) }
 
@@ -193,6 +199,28 @@ describe RailsParam::Coercion::TimeParam do
 
           it_behaves_like "raises ArgumentError"
         end
+      end
+    end
+
+    context "param is blank (e.g. empty field in an HTML form)" do
+      let(:param) { "" }
+
+      context "type is Date" do
+        let(:type) { Date }
+
+        it_behaves_like "returns nil"
+      end
+
+      context "type is Time" do
+        let(:type) { Time }
+
+        it_behaves_like "returns nil"
+      end
+
+      context "type is DateTime" do
+        let(:type) { DateTime }
+
+        it_behaves_like "returns nil"
       end
     end
   end

--- a/spec/rails_param/param_spec.rb
+++ b/spec/rails_param/param_spec.rb
@@ -125,6 +125,12 @@ describe RailsParam do
           expect(controller.params["foo"]).to eql(42)
         end
 
+        it "will allow a nil value (e.g. from an empty field in an HTML form)" do
+          allow(controller).to receive(:params).and_return({ "foo" => "" })
+          controller.param! :foo, Integer
+          expect(controller.params["foo"]).to be nil
+        end
+
         it "will raise InvalidParameterError if the value is not valid" do
           allow(controller).to receive(:params).and_return({ "foo" => "notInteger" })
           expect { controller.param! :foo, Integer }.to(
@@ -149,6 +155,12 @@ describe RailsParam do
           allow(controller).to receive(:params).and_return({ "foo" => "42.22" })
           controller.param! :foo, Float
           expect(controller.params["foo"]).to eql(42.22)
+        end
+
+        it "will allow a nil value (e.g. from an empty field in an HTML form)" do
+          allow(controller).to receive(:params).and_return({ "foo" => "" })
+          controller.param! :foo, Float
+          expect(controller.params["foo"]).to be nil
         end
 
         it "will raise InvalidParameterError if the value is not valid" do
@@ -601,6 +613,13 @@ describe RailsParam do
             raise_error(RailsParam::InvalidParameterError, "Parameter price is required") do |error|
               expect(error.param).to eq "price"
             end
+          )
+        end
+
+        it "raises on a nil value (e.g. from an empty field in an HTML form)" do
+          allow(controller).to receive(:params).and_return({ "foo" => "" })
+          expect { controller.param! :foo, BigDecimal, required: true }.to(
+            raise_error(RailsParam::InvalidParameterError, "Parameter foo is required")
           )
         end
 


### PR DESCRIPTION
## Description

When using an HTML form for searching or filtering and a field is left blank, Rails puts an empty string in the params hash, and this raised an unexpected `InvalidParameterError` when we defined the param as a non-required Integer, Float, Date, etc.

Now we will treat that empty string as an un-supplied param and only reject it if the param is flagged as required.

## Additional Notes

- added shared examples for Float tests
- nested shared examples in the appropriate scope

I suggested this improvement for the `rails_param` gem over a year ago (https://github.com/nicolasblanco/rails_param/pull/103) - the maintainers mistakenly thought this was a breaking change for JSON APIs and declined to provide an example.